### PR TITLE
two digit hours

### DIFF
--- a/jquery.dateFormat-1.0.js
+++ b/jquery.dateFormat-1.0.js
@@ -193,7 +193,9 @@
                             break;
                         case "hh":
                             /* time.hour is "00" as string == is used instead of === */
-                            retValue += (time.hour == 0 ? 12 : time.hour < 13 ? time.hour : time.hour - 12);
+                            var hour = (time.hour == 0 ? 12 : time.hour < 13 ? time.hour : time.hour - 12);
+                            hour = String(hour).length == 1 ? '0'+hour : hour;
+                            retValue += hour;
                             pattern = "";
                             break;
                         case "mm":


### PR DESCRIPTION
Hi Pablo.  I noticed that the "hh" returns two digits for single digit am hours but not for single digit pm hours (e.g., 06 AM but 6 PM).  I updated the "hh" pattern to always return two digits.
