### PR TITLE
Swichted to double quotations, because single quotations are not valid in JSON

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,19 +1,19 @@
 {
-  name:     'jquery-dateFormat',
-  homepage: 'https://github.com/phstc/jquery-dateFormat',
-  version:  '0.0.1',
+  name:     "jquery-dateFormat",
+  homepage: "https://github.com/phstc/jquery-dateFormat",
+  version:  "0.0.1",
   ignore: [
-    'src',
-    'test',
-    'coverage',
-    '.bowerrc',
-    '.gitignore',
-    '.jshintignore',
-    '.jshintrc',
-    'composer.json',
-    'bower.json',
-    'Gruntfile.js',
-    'package.json',
-    'README.md'
+    "src",
+    "test",
+    "coverage",
+    ".bowerrc",
+    ".gitignore",
+    ".jshintignore",
+    ".jshintrc",
+    "composer.json",
+    "bower.json",
+    "Gruntfile.js",
+    "package.json",
+    "README.md"
   ]
 }


### PR DESCRIPTION
Single Quotations are not valid in JSON
