### PR TITLE
added a main property to bower.json in order to be compatible with grunt...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name":     "jquery-dateFormat",
   "homepage": "https://github.com/phstc/jquery-dateFormat",
   "version":  "1.0.1",
+  "main": "./dist/jquery-dateFormat.js",
   "ignore": [
     "src",
     "test",


### PR DESCRIPTION
Hi,

In order to use this jquery-plugin with latest versions of yeoman, I had to manually add the main property to the bower.json file. Here is the patch
