### PR TITLE
fix typo in readme example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -66,7 +66,7 @@ The patterns to formatting are based on {java.text.SimpleDateFormat}[http://docs
 ==== Output
 
  => Test: 18/12/2009
- => 18~12~2009
+ => 13~01~2010
 
 === Formatting using css classes
 


### PR DESCRIPTION
Very minor detail!

The second example seems to be for a different date: `document.write($.format.date("Wed Jan 13 10:43:41 CET 2010", "dd~MM~yyyy"));`

So I updated the expected output below it with the correct date.