### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ jquery-dateFormat - jQuery Plugin to format Date outputs using JavaScript - ***H
 Download latest jquery.dateFormat.js or jquery.dateFormat.min.js.
 
 * [jquery-dateFormat.js](https://raw.githubusercontent.com/phstc/jquery-dateFormat/master/dist/jquery-dateformat.js)
-* [jquery-dateFormat.min.js](https://raw.githubusercontent.com/phstc/jquery-dateFormat/master/dist/dateFormat.min.js)
+* [jquery-dateFormat.min.js](https://raw.githubusercontent.com/phstc/jquery-dateFormat/master/dist/jquery-dateformat.min.js)
 * [dateFormat.js](https://raw.github.com/phstc/jquery-dateFormat/master/dist/dateFormat.js) (pure Javascript, no jQuery dependency)
 * [dateFormat.min.js](https://raw.github.com/phstc/jquery-dateFormat/master/dist/dateFormat.min.js) (pure Javascript, no jQuery dependency)
 


### PR DESCRIPTION
Fixed wrong link to the jquery.min file. Link URL for "jquery-dateFormat.min.js" in Installation section is "https://raw.githubusercontent.com/phstc/jquery-dateFormat/master/dist/dateFormat.min.js", but correct value should be "https://raw.githubusercontent.com/phstc/jquery-dateFormat/master/dist/jquery-dateformat.min.js"